### PR TITLE
  :white_check_mark: test: increase tests coverage

### DIFF
--- a/packages/repository/src/entity/deepReadonly.test.ts
+++ b/packages/repository/src/entity/deepReadonly.test.ts
@@ -88,6 +88,6 @@ describe("Deep Readonly", () => {
 
     expect(readonlyObj).toBe(obj)
     expect(readonlyObj.func).toBe(obj.func)
-    expect((readonlyObj.func as () => string)()).toBe("baz")
+    expect(readonlyObj.func()).toBe("baz")
   })
 })

--- a/packages/repository/src/entity/deepReadonly.test.ts
+++ b/packages/repository/src/entity/deepReadonly.test.ts
@@ -78,4 +78,16 @@ describe("Deep Readonly", () => {
       readonlyObj.bar.foo = "baz"
     }).toThrow()
   })
+
+  it("Given an object with function, When deepReadonly is called, Then return the same object with function", () => {
+    const obj = {
+      func: () => "baz",
+    }
+
+    const readonlyObj = deepReadonly(obj)
+
+    expect(readonlyObj).toBe(obj)
+    expect(readonlyObj.func).toBe(obj.func)
+    expect((readonlyObj.func as () => string)()).toBe("baz")
+  })
 })

--- a/packages/repository/src/entity/deepReadonly.ts
+++ b/packages/repository/src/entity/deepReadonly.ts
@@ -1,11 +1,14 @@
 export type DeepReadonly<TData> = {
-  readonly [Key in keyof TData]: TData[Key] extends (...args: any[]) => any
-    ? TData[Key]
-    : TData[Key] extends Record<string, any>
-      ? TData[Key] extends Set<any> | Map<any, any> | Date | RegExp
-        ? TData[Key]
-        : DeepReadonly<TData[Key]>
-      : TData[Key]
+  readonly [Key in keyof TData]: TData[Key] extends Record<string, any>
+    ? TData[Key] extends
+        | Set<any>
+        | Map<any, any>
+        | Date
+        | RegExp
+        | ((...args: any[]) => any)
+      ? TData[Key]
+      : DeepReadonly<TData[Key]>
+    : TData[Key]
 }
 
 export function deepReadonly<TWriteableObject extends Record<string, any>>(

--- a/packages/repository/src/entity/deepReadonly.ts
+++ b/packages/repository/src/entity/deepReadonly.ts
@@ -1,9 +1,11 @@
 export type DeepReadonly<TData> = {
-  readonly [Key in keyof TData]: TData[Key] extends Record<string, any>
-    ? TData[Key] extends Set<any> | Map<any, any> | Date | RegExp
-      ? TData[Key]
-      : DeepReadonly<TData[Key]>
-    : TData[Key]
+  readonly [Key in keyof TData]: TData[Key] extends (...args: any[]) => any
+    ? TData[Key]
+    : TData[Key] extends Record<string, any>
+      ? TData[Key] extends Set<any> | Map<any, any> | Date | RegExp
+        ? TData[Key]
+        : DeepReadonly<TData[Key]>
+      : TData[Key]
 }
 
 export function deepReadonly<TWriteableObject extends Record<string, any>>(

--- a/packages/repository/src/entity/identifier.test.ts
+++ b/packages/repository/src/entity/identifier.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest"
+import { getIdentifier } from "./identifier"
+
+describe("getIdentifier", () => {
+  it("Given getIdentifier function with no identifier, When called, Then return function that gets the id field", ({
+    fakeData,
+  }) => {
+    const getID = getIdentifier<typeof fakeData, undefined>()
+
+    expect(getID(fakeData)).toBe(fakeData.id)
+  })
+
+  it("Given getIdentifier function with string identifier, When called, Then return function that gets the specified field", ({
+    fakeData,
+  }) => {
+    fakeData.foo = "foo"
+    const getId = getIdentifier<typeof fakeData, "foo">("foo")
+
+    expect(getId(fakeData)).toBe("foo")
+  })
+
+  it("Given getIdentifier function with function identifier, When called, Then return the provided function", ({
+    fakeData,
+  }) => {
+    const getID = getIdentifier<
+      typeof fakeData,
+      (data: typeof fakeData) => string
+    >(() => "randomId")
+
+    expect(getID(fakeData)).toBe("randomId")
+  })
+})

--- a/packages/repository/src/entity/interface/data.test-d.ts
+++ b/packages/repository/src/entity/interface/data.test-d.ts
@@ -23,4 +23,10 @@ describe("User Input Data types", () => {
 
     expectTypeOf<Test>().toEqualTypeOf<string>()
   })
+
+  it("ResolveIdentifier returns default identifier if identifier is string literal but not keyof TSchema", () => {
+    type Test = ResolveIdentifier<TestEntityData, "nonexistentKey">
+
+    expectTypeOf<Test>().toEqualTypeOf<string>()
+  })
 })


### PR DESCRIPTION
Dwie małe zmiany i dopisany test do identifier.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Testy**
    - Dodano test sprawdzający zachowanie `deepReadonly` z funkcjami.
    - Dodano test dla `ResolveIdentifier` z identyfikatorem w postaci literału ciągu znaków, nie będącego `keyof TSchema`.
    - Dodano funkcjonalność testującą funkcję `getIdentifier`, która zwraca funkcję do ekstrakcji konkretnych pól z obiektów danych na podstawie różnych typów identyfikatorów.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->