### PR TITLE
:recycle: refactor: test cases titles to be more descriptive

### DIFF
--- a/packages/repository/src/network/sync.test.ts
+++ b/packages/repository/src/network/sync.test.ts
@@ -22,7 +22,7 @@ describe("SyncMap", () => {
     })
   })
 
-  it("Given one destination ID, When SyncMap is created, Then SyncMap has one destination", ({
+  it("Given one destination ID, When SyncMap is created, Then status for the ID is false", ({
     syncMapDestinationId: destinationId,
   }) => {
     const syncMap = new SyncMap([destinationId])
@@ -30,7 +30,7 @@ describe("SyncMap", () => {
     expect(syncMap.checkStatus(destinationId)).toBe(false)
   })
 
-  it("Given two the same destination IDs, When SyncMap is created, Then SyncMap has one destination", ({
+  it("Given two the same destination IDs, When SyncMap is created, Then status for the ID is false", ({
     syncMapDestinationId: destinationId,
   }) => {
     const syncMap = new SyncMap([destinationId, destinationId])
@@ -38,7 +38,7 @@ describe("SyncMap", () => {
     expect(syncMap.checkStatus(destinationId)).toBe(false)
   })
 
-  it("Given couple destination IDs, When SyncMap is created, Then SyncMap has many destinations", ({
+  it("Given multiple destination IDs, When SyncMap is created, Then status for each ID is false", ({
     syncMapDestinationId: firstDestinationId,
   }) => {
     const secondDestinationId = makeSyncKey("other-destination-id")


### PR DESCRIPTION
Tytuły testów jak dla mnie były trochę mylące, bo nie odzwierciedlały tego co było w asercjach i na początku musiałem trochę pomyśleć WHY, co myślicie o tej zmianie?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Poprawki błędów**
    - Zmodyfikowano zachowanie klasy `SyncMap` przy sprawdzaniu statusu ID docelowych na zwracanie wartości `false`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->