### PR TITLE
test: refactor proxy handler factory unit

### DIFF
--- a/packages/repository/src/entity/proxyHandlerFactory.test.ts
+++ b/packages/repository/src/entity/proxyHandlerFactory.test.ts
@@ -177,7 +177,7 @@ describe("proxyHandlerFactory", () => {
     ).toBeUndefined()
   })
 
-  it("Given proxy with handler, When delete property, Then throw error", ({
+  it("Given proxy with handler, When try to overwrite property, Then throw error", ({
     testProxy,
   }) => {
     expect(() => {
@@ -185,6 +185,14 @@ describe("proxyHandlerFactory", () => {
     }).toThrowError(
       "You can't overwrite entity properties, use update() instead."
     )
+  })
+
+  it("Given proxy with handler, When delete property, Then throw error", ({
+    testProxy,
+  }) => {
+    expect(() => {
+      testProxy.fakeKey = undefined
+    }).toThrowError("You can't delete entity properties, use update() instead.")
   })
 
   it("Given proxy with handler, When defineProperty, Then do nothing", ({

--- a/packages/repository/vitest.config.ts
+++ b/packages/repository/vitest.config.ts
@@ -11,7 +11,7 @@ export default defineConfig({
     coverage: {
       provider: "istanbul",
       reporter: ["text", "json", "json-summary", "html", "lcov"],
-      exclude: [...(configDefaults.coverage?.exclude ?? []), "**/*.test-d.ts"],
+      exclude: [...(configDefaults.coverage?.exclude ?? []), "**/*.test-d.ts", "**/*.mjs"],
       thresholds: {
         lines: 80,
         statements: 80,


### PR DESCRIPTION
Plik mjs wliczał się do pokrycia, no i w teście był tak mi się wydaje malutki miss :D @grixu 